### PR TITLE
Fix broken link in Llama Stack tutorial

### DIFF
--- a/docs/notebooks/inference/llama-stack-rocm.ipynb
+++ b/docs/notebooks/inference/llama-stack-rocm.ipynb
@@ -97,7 +97,7 @@
    "source": [
     "## Deployment of Llama Stack with ROCm\n",
     "\n",
-    "This tutorial uses [Remote vLLM Distribution](https://llama-stack.readthedocs.io/en/latest/distributions/self_hosted_distro/remote-vllm.html#remote-vllm-distribution) running with the ROCm/vllm-dev Docker image on an Instinct MI300X GPU. In addition to supporting many LLM inference providers (for example, Fireworks, Together, AWS Bedrock, Groq, Cerebras, SambaNova, and vLLM), Llama Stack also allows you to choose safety providers as an option (for instance, Meta Llama Guard, AWS Bedrock Guardrails, and vLLM). This tutorial uses two Instinct MI300X GPUs: one for deploying LLM inference APIs, and another for deploying the Safety or Shield APIs."
+    "This tutorial uses [Remote vLLM Distribution](https://llama-stack.readthedocs.io/en/v0.2.9/distributions/self_hosted_distro/remote-vllm.html) running with the ROCm/vllm-dev Docker image on an Instinct MI300X GPU. In addition to supporting many LLM inference providers (for example, Fireworks, Together, AWS Bedrock, Groq, Cerebras, SambaNova, and vLLM), Llama Stack also allows you to choose safety providers as an option (for instance, Meta Llama Guard, AWS Bedrock Guardrails, and vLLM). This tutorial uses two Instinct MI300X GPUs: one for deploying LLM inference APIs, and another for deploying the Safety or Shield APIs."
    ]
   },
   {


### PR DESCRIPTION
Fixes a broken link in the Llama Stack tutorial to the Remote VLLM distribution documentation.