### PR TITLE
The PydanticAI MCP notebook needs updating to PydanticAI V2.0 API

### DIFF
--- a/docs/notebooks/inference/build_airbnb_agent_mcp.ipynb
+++ b/docs/notebooks/inference/build_airbnb_agent_mcp.ipynb
@@ -236,7 +236,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q pydantic-ai-slim openai"
+        "!pip install -q \"pydantic-ai-slim[mcp]>=2.0\" openai"
       ]
     },
     {
@@ -315,10 +315,8 @@
       },
       "outputs": [],
       "source": [
-        "import asyncio\n",
-        "from pydantic_ai.mcp import MCPServerStdio\n",
         "async def run_async(prompt: str) -> str:\n",
-        "    async with agent.run_mcp_servers():\n",
+        "    async with agent:\n",
         "        result = await agent.run(prompt)\n",
         "        return result.output\n"
       ]
@@ -508,14 +506,17 @@
       },
       "outputs": [],
       "source": [
-        "from pydantic_ai.mcp import MCPServerStdio\n",
+        "from fastmcp.client.transports import StdioTransport\n",
+        "from pydantic_ai.mcp import MCPToolset\n",
         "\n",
-        "time_server = MCPServerStdio(\n",
-        "    \"python\",\n",
-        "    args=[\n",
-        "        \"-m\", \"mcp_server_time\",\n",
-        "        \"--local-timezone=America/New_York\",\n",
-        "    ],\n",
+        "time_server = MCPToolset(\n",
+        "    StdioTransport(\n",
+        "        command=\"python\",\n",
+        "        args=[\n",
+        "            \"-m\", \"mcp_server_time\",\n",
+        "            \"--local-timezone=America/New_York\",\n",
+        "        ],\n",
+        "    ),\n",
         ")"
       ]
     },
@@ -644,8 +645,11 @@
       },
       "outputs": [],
       "source": [
-        "airbnb_server = MCPServerStdio(\n",
-        "    \"npx\", args=[\"-y\", \"@openbnb/mcp-server-airbnb\", \"--ignore-robots-txt\"]\n",
+        "airbnb_server = MCPToolset(\n",
+        "    StdioTransport(\n",
+        "        command=\"npx\",\n",
+        "        args=[\"-y\", \"@openbnb/mcp-server-airbnb\", \"--ignore-robots-txt\"],\n",
+        "    ),\n",
         ")"
       ]
     },

--- a/workshops/airbnb_agent/build_airbnb_agent_mcp.ipynb
+++ b/workshops/airbnb_agent/build_airbnb_agent_mcp.ipynb
@@ -167,7 +167,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q pydantic_ai openai     "
+        "!pip install -q \"pydantic-ai[mcp]>=2.0\" openai"
       ]
     },
     {
@@ -192,7 +192,7 @@
       },
       "outputs": [],
       "source": [
-        "from pydantic_ai.models.openai import OpenAIModel\n",
+        "from pydantic_ai.models.openai import OpenAIChatModel\n",
         "from pydantic_ai.providers.openai import OpenAIProvider\n",
         "\n",
         "provider = OpenAIProvider(\n",
@@ -200,7 +200,7 @@
         "    api_key=os.environ[\"OPENAI_API_KEY\"],\n",
         ")\n",
         "\n",
-        "agent_model = OpenAIModel(\"Qwen3-30B-A3B\", provider=provider)"
+        "agent_model = OpenAIChatModel(\"Qwen3-30B-A3B\", provider=provider)"
       ]
     },
     {
@@ -246,10 +246,8 @@
       },
       "outputs": [],
       "source": [
-        "import asyncio\n",
-        "from pydantic_ai.mcp import MCPServerStdio\n",
         "async def run_async(prompt: str) -> str:\n",
-        "    async with agent.run_mcp_servers():\n",
+        "    async with agent:\n",
         "        result = await agent.run(prompt)\n",
         "        return result.output\n"
       ]
@@ -439,14 +437,17 @@
       },
       "outputs": [],
       "source": [
-        "from pydantic_ai.mcp import MCPServerStdio\n",
+        "from fastmcp.client.transports import StdioTransport\n",
+        "from pydantic_ai.mcp import MCPToolset\n",
         "\n",
-        "time_server = MCPServerStdio(\n",
-        "    \"python\",\n",
-        "    args=[\n",
-        "        \"-m\", \"mcp_server_time\",\n",
-        "        \"--local-timezone=America/New_York\",\n",
-        "    ],\n",
+        "time_server = MCPToolset(\n",
+        "    StdioTransport(\n",
+        "        command=\"python\",\n",
+        "        args=[\n",
+        "            \"-m\", \"mcp_server_time\",\n",
+        "            \"--local-timezone=America/New_York\",\n",
+        "        ],\n",
+        "    ),\n",
         ")"
       ]
     },
@@ -575,8 +576,11 @@
       },
       "outputs": [],
       "source": [
-        "airbnb_server = MCPServerStdio(\n",
-        "    \"npx\", args=[\"-y\", \"@openbnb/mcp-server-airbnb\", \"--ignore-robots-txt\"]\n",
+        "airbnb_server = MCPToolset(\n",
+        "    StdioTransport(\n",
+        "        command=\"npx\",\n",
+        "        args=[\"-y\", \"@openbnb/mcp-server-airbnb\", \"--ignore-robots-txt\"],\n",
+        "    ),\n",
         ")"
       ]
     },


### PR DESCRIPTION
## Summary

- Migrate both Airbnb MCP notebooks from the removed `MCPServerStdio` and `run_mcp_servers()` APIs to `MCPToolset`, FastMCP `StdioTransport`, and the agent async context manager.
- Require PydanticAI 2.0+ with MCP support and update the workshop copy to `OpenAIChatModel`.

Closes #111.

## Validation

- Confirmed the legacy-API guard fails before the change and passes afterward.
- Parsed and compiled 15 Python code cells in each notebook.
- Executed 10 setup cells in each notebook against PydanticAI 2.23.0, including model, toolset, transport, and agent construction.
- Static, build, test-integrity, and independent validation gates passed (`fix_confirmed=true`).

## Disclosure

This change was prepared with assistance from the radeon-issue automation and independently checked by a separately configured validation model. Maintainer review is still required.